### PR TITLE
Fix panic caused by large writes

### DIFF
--- a/memfs/buffer.go
+++ b/memfs/buffer.go
@@ -99,7 +99,11 @@ func (v *Buf) Read(p []byte) (n int, err error) {
 func (v *Buf) grow(n int) error {
 	m := len(*v.buf)
 	if (m + n) > cap(*v.buf) {
-		buf, err := makeSlice(2*cap(*v.buf) + MinBufferSize)
+		size := 2*cap(*v.buf) + MinBufferSize
+		if size < n {
+			size = n + MinBufferSize
+		}
+		buf, err := makeSlice(size)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
If `len(p) > 2*cap(buf) + MinBufferSize`, `grow` panics due to a `slice bounds out of range`.