### PR TITLE
add File.Truncate() implementation

### DIFF
--- a/dummy.go
+++ b/dummy.go
@@ -86,6 +86,11 @@ func (f DumFile) Sync() error {
 	return f.err
 }
 
+// Truncate returns dummy error
+func (f DumFile) Truncate(size int64) error {
+	return f.err
+}
+
 // Close returns dummy error
 func (f DumFile) Close() error {
 	return f.err

--- a/filesystem.go
+++ b/filesystem.go
@@ -37,6 +37,8 @@ type Filesystem interface {
 type File interface {
 	Name() string
 	Sync() error
+	// Truncate shrinks or extends the size of the File to the specified size.
+	Truncate(int64) error
 	io.Reader
 	io.Writer
 	io.Seeker

--- a/memfs/memfile.go
+++ b/memfs/memfile.go
@@ -34,6 +34,14 @@ func (b MemFile) Sync() error {
 	return nil
 }
 
+// Truncate changes the size of the file
+func (b MemFile) Truncate(size int64) (err error) {
+	b.mutex.Lock()
+	err = b.Buffer.Truncate(size)
+	b.mutex.Unlock()
+	return
+}
+
 // Read reads len(p) byte from the underlying buffer starting at the current offset.
 // It returns the number of bytes read and an error if any.
 // Returns io.EOF error if pointer is at the end of the Buffer.


### PR DESCRIPTION
Resolve https://github.com/blang/vfs/issues/10.

This pull request adds a new Truncate() API to the File interface.  It also implements the API for memfs.