### PR TITLE
Add ReadFile and WriteFile utils from stdlib

### DIFF
--- a/ioutil.go
+++ b/ioutil.go
@@ -1,6 +1,7 @@
 package vfs
 
 import (
+	"bytes"
 	"io"
 	"os"
 )
@@ -23,4 +24,60 @@ func WriteFile(fs Filesystem, filename string, data []byte, perm os.FileMode) er
 		err = err1
 	}
 	return err
+}
+
+// ReadFile reads the file named by filename and returns the contents. A
+// successful call returns err == nil, not err == EOF. Because ReadFile reads
+// the whole file, it does not treat an EOF from Read as an error to be
+// reported.
+//
+// This is a port of the stdlib ioutil.ReadFile function.
+func ReadFile(fs Filesystem, filename string) ([]byte, error) {
+	f, err := fs.OpenFile(filename, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	// It's a good but not certain bet that FileInfo will tell us exactly how
+	// much to read, so let's try it but be prepared for the answer to be wrong.
+	var n int64
+	if fi, err := fs.Stat(filename); err == nil {
+		if size := fi.Size(); size < 1e9 {
+			n = size
+		}
+	}
+
+    // As initial capacity for readAll, use n + a little extra in case Size is
+    // zero, and to avoid another allocation after Read has filled the buffer.
+    // The readAll call will read into its allocated internal buffer cheaply. If
+    // the size was wrong, we'll either waste some space off the end or
+    // reallocate as needed, but in the overwhelmingly common case we'll get it
+    // just right.
+	return readAll(f, n+bytes.MinRead)
+}
+
+// readAll reads from r until an error or EOF and returns the data it read from
+// the internal buffer allocated with a specified capacity.
+//
+// This is a paste of the stdlib ioutil.readAll function.
+func readAll(r io.Reader, capacity int64) (b []byte, err error) {
+	buf := bytes.NewBuffer(make([]byte, 0, capacity))
+
+	// If the buffer overflows, we will get bytes.ErrTooLarge.
+	// Return that as an error. Any other panic remains.
+	defer func() {
+		e := recover()
+		if e == nil {
+			return
+		}
+		if panicErr, ok := e.(error); ok && panicErr == bytes.ErrTooLarge {
+			err = panicErr
+		} else {
+			panic(e)
+		}
+	}()
+
+	_, err = buf.ReadFrom(r)
+	return buf.Bytes(), err
 }

--- a/ioutil.go
+++ b/ioutil.go
@@ -1,0 +1,26 @@
+package vfs
+
+import (
+	"io"
+	"os"
+)
+
+// WriteFile writes data to a file named by filename on the given Filesystem. If
+// the file does not exist, WriteFile creates it with permissions perm;
+// otherwise WriteFile truncates it before writing.
+//
+// This is a port of the stdlib ioutil.WriteFile function.
+func WriteFile(fs Filesystem, filename string, data []byte, perm os.FileMode) error {
+	f, err := fs.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	n, err := f.Write(data)
+	if err == nil && n < len(data) {
+		err = io.ErrShortWrite
+	}
+	if err1 := f.Close(); err == nil {
+		err = err1
+	}
+	return err
+}

--- a/ioutil_test.go
+++ b/ioutil_test.go
@@ -1,0 +1,33 @@
+package vfs_test
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/blang/vfs"
+	"github.com/blang/vfs/memfs"
+)
+
+var (
+	testpath = "/example.txt"
+	testmode = os.FileMode(0600)
+	testdata = bytes.Repeat([]byte("abcdefghijklmnopqrstuvwxyz"), 100)
+)
+
+func TestWriteFile(t *testing.T) {
+	fs := memfs.Create()
+
+	vfs.WriteFile(fs, testpath, testdata, testmode)
+
+	info, err := fs.Stat(testpath)
+	if err != nil {
+		t.Fatalf("File not created")
+	}
+	if info.Size() != int64(len(testdata)) {
+		t.Fatalf("Bad file size: %d bytes (expected %d)", info.Size(), len(testdata))
+	}
+	if info.Mode() != testmode {
+		t.Fatalf("Bad file mode: %o (expected %o)", info.Mode(), testmode)
+	}
+}

--- a/ioutil_test.go
+++ b/ioutil_test.go
@@ -31,3 +31,24 @@ func TestWriteFile(t *testing.T) {
 		t.Fatalf("Bad file mode: %o (expected %o)", info.Mode(), testmode)
 	}
 }
+
+func TestReadFile(t *testing.T) {
+	fs := memfs.Create()
+
+	f, _ := fs.OpenFile(testpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, testmode)
+	f.Write(testdata)
+	f.Close()
+
+	data, err := vfs.ReadFile(fs, testpath)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %s", err)
+	}
+	if len(data) != len(testdata) {
+		t.Fatalf("Bad data length: %d bytes (expected %d)", len(data), len(testdata))
+	}
+
+	_, err = vfs.ReadFile(fs, "/doesnt-exist.txt")
+	if err == nil {
+		t.Fatalf("ReadFile failed: expected error")
+	}
+}


### PR DESCRIPTION
I'm not sure if this is useful or desirable to include, but I've pasted these functions into a number of my test suites to make it simpler to read and write files into a memfs. They're straight ports from the stdlib.