### PR TITLE
fix(memfs): do not update mtime on readonly opens

### DIFF
--- a/memfs/memfs.go
+++ b/memfs/memfs.go
@@ -79,7 +79,7 @@ func (fi fileInfo) IsDir() bool {
 // Modification time is updated on:
 // 	- Creation
 // 	- Rename
-// 	- Open
+// 	- Open (except with O_RDONLY)
 func (fi fileInfo) ModTime() time.Time {
 	return fi.modTime
 }
@@ -254,7 +254,9 @@ func (fs *MemFS) OpenFile(name string, flag int, perm os.FileMode) (vfs.File, er
 			return nil, &os.PathError{"open", name, ErrIsDirectory}
 		}
 	}
-	fiNode.modTime = time.Now()
+	if !hasFlag(os.O_RDONLY, flag) {
+		fiNode.modTime = time.Now()
+	}
 	return fiNode.file(flag)
 }
 

--- a/memfs/memfs_test.go
+++ b/memfs/memfs_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/blang/vfs"
 )
@@ -538,4 +539,28 @@ func TestRename(t *testing.T) {
 		t.Errorf("Expected error renaming file")
 	}
 
+}
+
+func TestModTime(t *testing.T) {
+	fs := Create()
+
+	tBeforeWrite := time.Now()
+	writeFile(fs, "/readme.txt", os.O_CREATE|os.O_RDWR, 0666, []byte{0, 0, 0})
+	fi, _ := fs.Stat("/readme.txt")
+	mtimeAfterWrite := fi.ModTime()
+
+	if !mtimeAfterWrite.After(tBeforeWrite) {
+		t.Error("Open should modify mtime")
+	}
+
+	f, err := fs.OpenFile("/readme.txt", os.O_RDONLY, 0666)
+	if err != nil {
+		t.Fatalf("Could not open file: %s", err)
+	}
+	f.Close()
+	tAfterRead := fi.ModTime()
+
+	if tAfterRead != mtimeAfterWrite {
+		t.Error("Open with O_RDONLY should not modify mtime")
+	}
 }


### PR DESCRIPTION
I'm trying to use this package with `net/http` [ServeContent](https://golang.org/pkg/net/http/#ServeContent) and `Last-Modified` is always set at current time. This happens because I open the file on each request for reading and mtime is updated.

Disabling mtime update fixes the issue