### PR TITLE
memfs: When using O_CREATE, the file is allowed to exist, unless O_EXCL

### DIFF
--- a/memfs/memfs_test.go
+++ b/memfs/memfs_test.go
@@ -26,13 +26,29 @@ func TestCreate(t *testing.T) {
 		}
 	}
 
-	// Create same file twice, no error because os.O_TRUNC is used
+	// Create same file again
+	{
+		_, err := fs.OpenFile("/testfile", os.O_RDWR|os.O_CREATE, 0666)
+		if err != nil {
+			t.Fatalf("Unexpected error creating file: %s", err)
+		}
+
+	}
+
+	// Create same file again, but truncate it
 	{
 		_, err := fs.OpenFile("/testfile", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
 		if err != nil {
+			t.Fatalf("Unexpected error creating file: %s", err)
+		}
+	}
+
+	// Create same file again with O_CREATE|O_EXCL, which is an error
+	{
+		_, err := fs.OpenFile("/testfile", os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
+		if err == nil {
 			t.Fatalf("Expected error creating file: %s", err)
 		}
-
 	}
 
 	// Create file with unkown parent


### PR DESCRIPTION
OpenFile currently gives an error if O_CREATE is passed and the file
already exists. This is not how O_CREATE is meant to work. O_CREATE
requests the file to be created if it does not exist. However, if O_EXCL
is also set, then the file must not exist.

Implement and test this behavior.