### PR TITLE
Add Readlink support

### DIFF
--- a/dummy.go
+++ b/dummy.go
@@ -56,6 +56,11 @@ func (fs DummyFS) ReadDir(path string) ([]os.FileInfo, error) {
 	return nil, fs.err
 }
 
+// Readlink returns dummy error
+func (fs DummyFS) Readlink(name string) (string, error) {
+        return "dummy", fs.err
+}
+
 // DummyFile mocks a File returning an error on every operation
 // To create a DummyFS returning a dummyFile instead of an error
 // you can your own DummyFS:

--- a/filesystem.go
+++ b/filesystem.go
@@ -29,6 +29,7 @@ type Filesystem interface {
 	Stat(name string) (os.FileInfo, error)
 	Lstat(name string) (os.FileInfo, error)
 	ReadDir(path string) ([]os.FileInfo, error)
+	Readlink(name string) (string, error)
 }
 
 // File represents a File with common operations.

--- a/memfs/memfs.go
+++ b/memfs/memfs.go
@@ -381,3 +381,7 @@ func (fs *MemFS) Stat(name string) (os.FileInfo, error) {
 func (fs *MemFS) Lstat(name string) (os.FileInfo, error) {
 	return fs.Stat(name)
 }
+
+func (fs *MemFS) Readlink(name string) (string, error) {
+        return fs.Readlink(name)
+}

--- a/mountfs/mountfs.go
+++ b/mountfs/mountfs.go
@@ -177,3 +177,13 @@ func (fs MountFS) ReadDir(path string) ([]os.FileInfo, error) {
 	}
 	return fis, err
 }
+
+// Readlink returns the destination of a link
+func (fs MountFS) Readlink(name string) (string, error) {
+	mount, innerPath := findMount(name, fs.mounts, fs.rootFS, string(fs.PathSeparator()))
+        path, err := mount.Readlink(innerPath)
+	if innerPath == "/" {
+		return filepath.Base(name), err
+	}
+	return path, err
+}

--- a/os.go
+++ b/os.go
@@ -52,3 +52,7 @@ func (fs OsFS) Lstat(name string) (os.FileInfo, error) {
 func (fs OsFS) ReadDir(path string) ([]os.FileInfo, error) {
 	return ioutil.ReadDir(path)
 }
+
+func (fs OsFS) Readlink(name string) (string, error) {
+        return os.Readlink(name)
+}


### PR DESCRIPTION
Add Readlink to Filesystem, MountFS and MemFS. Readlink is just a
wrapper call to os.Readlink.Readlink().