### PR TITLE
symlink support

### DIFF
--- a/dummy.go
+++ b/dummy.go
@@ -41,6 +41,11 @@ func (fs DummyFS) Mkdir(name string, perm os.FileMode) error {
 	return fs.err
 }
 
+// Symlink returns dummy error
+func (fs DummyFS) Symlink(oldname, newname string) error {
+	return fs.err
+}
+
 // Stat returns dummy error
 func (fs DummyFS) Stat(name string) (os.FileInfo, error) {
 	return nil, fs.err

--- a/filesystem.go
+++ b/filesystem.go
@@ -22,7 +22,7 @@ type Filesystem interface {
 	// RemoveAll(path string) error
 	Rename(oldpath, newpath string) error
 	Mkdir(name string, perm os.FileMode) error
-	// Symlink(oldname, newname string) error
+	Symlink(oldname, newname string) error
 	// TempDir() string
 	// Chmod(name string, mode FileMode) error
 	// Chown(name string, uid, gid int) error

--- a/mountfs/mountfs.go
+++ b/mountfs/mountfs.go
@@ -127,6 +127,16 @@ func (fs MountFS) Mkdir(name string, perm os.FileMode) error {
 	return mount.Mkdir(innerPath, perm)
 }
 
+// Symlink creates a symlink
+func (fs MountFS) Symlink(oldname, newname string) error {
+	oldMount, oldInnerName := findMount(oldname, fs.mounts, fs.rootFS, string(fs.PathSeparator()))
+	newMount, newInnerName := findMount(newname, fs.mounts, fs.rootFS, string(fs.PathSeparator()))
+	if oldMount != newMount {
+		return ErrBoundary
+	}
+	return oldMount.Symlink(oldInnerName, newInnerName)
+}
+
 type innerFileInfo struct {
 	os.FileInfo
 	name string

--- a/os.go
+++ b/os.go
@@ -33,6 +33,11 @@ func (fs OsFS) Mkdir(name string, perm os.FileMode) error {
 	return os.Mkdir(name, perm)
 }
 
+// Symlink wraps os.Symlink
+func (fs OsFS) Symlink(oldname, newname string) error {
+	return os.Symlink(oldname, newname)
+}
+
 // Rename wraps os.Rename
 func (fs OsFS) Rename(oldpath, newpath string) error {
 	return os.Rename(oldpath, newpath)

--- a/prefixfs/prefixfs.go
+++ b/prefixfs/prefixfs.go
@@ -16,7 +16,7 @@ type FS struct {
 
 // Create returns a file system that prefixes all paths and forwards to root.
 func Create(root vfs.Filesystem, prefix string) *FS {
-	return &FS{root, prefix}
+	return &FS{Filesystem: root, Prefix: prefix}
 }
 
 // PrefixPath returns path with the prefix prefixed.
@@ -45,6 +45,11 @@ func (fs *FS) Rename(oldpath, newpath string) error {
 // Mkdir implements vfs.Filesystem.
 func (fs *FS) Mkdir(name string, perm os.FileMode) error {
 	return fs.Filesystem.Mkdir(fs.PrefixPath(name), perm)
+}
+
+// Symlink implements vfs.Filesystem.
+func (fs *FS) Symlink(oldname, newname string) error {
+	return fs.Filesystem.Symlink(fs.PrefixPath(oldname), fs.PrefixPath(newname))
 }
 
 // Stat implements vfs.Filesystem.

--- a/prefixfs/prefixfs_test.go
+++ b/prefixfs/prefixfs_test.go
@@ -103,6 +103,27 @@ func TestMkdir(t *testing.T) {
 	}
 }
 
+func TestSymlink(t *testing.T) {
+	rfs := rootfs()
+	fs := Create(rfs, prefixPath)
+
+	f, err := fs.OpenFile("file", os.O_CREATE, 0666)
+	defer f.Close()
+	if err != nil {
+		t.Errorf("OpenFile: %v", err)
+	}
+
+	err = fs.Symlink("/file", "file2")
+	if err != nil {
+		t.Errorf("Symlink: %v", err)
+	}
+
+	_, err = rfs.Stat(prefix("file2"))
+	if os.IsNotExist(err) {
+		t.Errorf("root:%v not found (%v)", prefix("file2"), err)
+	}
+}
+
 func TestStat(t *testing.T) {
 	rfs := rootfs()
 	fs := Create(rfs, prefixPath)

--- a/readonly.go
+++ b/readonly.go
@@ -44,6 +44,10 @@ func (fs RoFS) Mkdir(name string, perm os.FileMode) error {
 	return ErrReadOnly
 }
 
+func (fs RoFS) Symlink(oldname, newname string) error {
+	return ErrReadOnly
+}
+
 // OpenFile returns ErrorReadOnly if flag contains os.O_CREATE, os.O_APPEND, os.O_WRONLY.
 // Otherwise it returns a read-only File with disabled Write(..) operation.
 func (fs RoFS) OpenFile(name string, flag int, perm os.FileMode) (File, error) {

--- a/readonly_test.go
+++ b/readonly_test.go
@@ -66,6 +66,13 @@ func TestMkDir(t *testing.T) {
 	}
 }
 
+func TestROSymlink(t *testing.T) {
+	err := ro.Symlink("old", "new")
+	if err != ErrReadOnly {
+		t.Errorf("Symlink error expected")
+	}
+}
+
 type writeDummyFS struct {
 	Filesystem
 }


### PR DESCRIPTION
Hi @blang,

This PR adds support for the Symlink method to vfs. This is pretty straight forward on all Filesystem implementations except for MemFS, of course. In MemFS, it's probably still not a perfect analog of an OS filesystem, but I think it's a close enough start.

Thanks,
d#

CC: @goutamtadi1 @larham 